### PR TITLE
Expand version range of allowed hashbrown versions to include 0.15.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,4 +20,4 @@ std = []
 
 [dependencies]
 # The hashbrown feature, disabled by default, is exposed under different stability guarantees than the usual SemVer ones: by preference the version range will only be extended, but it may be shrunk in a MINOR release. See README.md.
-hashbrown = { version = ">=0.1.1, <0.13", optional = true }
+hashbrown = { version = ">=0.1.1, <0.16", optional = true }


### PR DESCRIPTION
Compiles and tests pass with the hashbrown feature enabled, but have not verified anything more than that.

Closes #1