### PR TITLE
Add `anymore` support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,11 +18,19 @@ jobs:
           # std
           - ""
           # std + hashbrown
+          - "--features hashbrown"
+          # std + anymore
+          - "--features anymore"
+          # std + hashbrown + anymore
           - "--all-features"
           # no_std
           - "--no-default-features"
           # no_std + hashbrown
           - "--no-default-features --features hashbrown"
+          # no_std + anymore
+          - "--no-default-features --features anymore"
+          # no_std + hashbrown + anymore
+          - "--no-default-features --features hashbrown,anymore"
     steps:
       - uses: actions/checkout@v4
       - uses: "dtolnay/rust-toolchain@master"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
+          # Our MSRV
           - 1.56.0
+          # Anymore MSRV
+          - 1.86.0
           - stable
         features:
           # std
@@ -31,6 +34,16 @@ jobs:
           - "--no-default-features --features anymore"
           # no_std + hashbrown + anymore
           - "--no-default-features --features hashbrown,anymore"
+        exclude:
+          # Anymore won't run on 1.56.0
+          - toolchain: 1.56.0
+            features: "--features anymore"
+          - toolchain: 1.56.0
+            features: "--all-features"
+          - toolchain: 1.56.0
+            features: "--no-default-features --features anymore"
+          - toolchain: 1.56.0
+            features: "--no-default-features --features hashbrown,anymore"
     steps:
       - uses: actions/checkout@v4
       - uses: "dtolnay/rust-toolchain@master"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- Add support for using `AnyDebug` (from Anymore) as the storage type, for better debugging.
+  This can be enabled through the `anymore` cargo feature.
+  If this feature is enabled, the MSRV is 1.86 (as that is Anymore's MSRV so it can use trait upcasting)
+
 # 1.0.1 (2024-11-09)
 
 - Suppress future incompatibility lint in CloneToAny impl. Contributed by @swlynch99 — thank you. ([#2](https://github.com/reivilibre/anymap3/pull/2))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,3 @@
-# Unreleased
-
-- Add support for using `AnyDebug` (from Anymore) as the storage type, for better debugging.
-  This can be enabled through the `anymore` cargo feature.
-  If this feature is enabled, the MSRV is 1.86 (as that is Anymore's MSRV so it can use trait upcasting)
 
 # anymap3 Changelog
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,5 +24,5 @@ std = []
 [dependencies]
 # The hashbrown feature, disabled by default, is exposed under different stability guarantees than the usual SemVer ones: by preference the version range will only be extended, but it may be shrunk in a MINOR release. See README.md.
 hashbrown = { version = ">=0.1.1, <0.16", optional = true }
-# If this feature is enabled, anymap3's MSRV is the same as Anymore's.
+# If this feature is enabled, anymap3's MSRV is raised by Anymore's.
 anymore = { version = "1.0.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ std = []
 [dependencies]
 # The hashbrown feature, disabled by default, is exposed under different stability guarantees than the usual SemVer ones: by preference the version range will only be extended, but it may be shrunk in a MINOR release. See README.md.
 hashbrown = { version = ">=0.1.1, <0.16", optional = true }
+# If this feature is enabled, anymap3's MSRV is the same as Anymore's.
 anymore = { version = "1.0.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "anymap3"
 version = "1.0.1"
-authors = ["Olivier 'reivilibre' (fork maintainer) <contact@librepush.net>", "Chris Morgan (original author) <rust@chrismorgan.info>"]
+authors = [
+    "Olivier 'reivilibre' (fork maintainer) <contact@librepush.net>",
+    "Chris Morgan (original author) <rust@chrismorgan.info>",
+]
 edition = "2018"
 rust-version = "1.36"
 description = "A safe and convenient store for one value of each type"
@@ -21,3 +24,4 @@ std = []
 [dependencies]
 # The hashbrown feature, disabled by default, is exposed under different stability guarantees than the usual SemVer ones: by preference the version range will only be extended, but it may be shrunk in a MINOR release. See README.md.
 hashbrown = { version = ">=0.1.1, <0.16", optional = true }
+anymore = { version = "1.0.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ anymap3 = { version = "1.0.1", default-features = false, features = ["hashbrown"
 
 This crate can also be used with `AnyDebug` from the [Anymore](https://docs.rs/anymore/latest/anymore) crate.
 This is enabled using the `anymore` cargo feature.
-If this feature is enabled, this crate's MSRV is the same as Anymore's.
+(Note that `anymore` has a more constrained Minimum Supported Rust Version.)
 
 ## Unsafe code in this library
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ anymap3 = { version = "1.0.1", default-features = false, features = ["hashbrown"
 
 **On stability:** hashbrown is still pre-1.0.0 and experiencing breaking changes. Because it’s useful for a small fraction of users, I am retaining it, but with *different compatibility guarantees to the typical SemVer ones*. Where possible, I will just widen the range for new releases of hashbrown, but if an incompatible change occurs, I may drop support for older versions of hashbrown with a bump to the *minor* part of the anymap version number (e.g. 1.1.0, 1.2.0). Iff you’re using this feature, this is cause to *consider* using a tilde requirement like `"~1.0"` (or spell it out as `>=1, <1.1`).
 
+This crate can also be used with `AnyDebug` from the [Anymore](https://docs.rs/anymore/latest/anymore) crate.
+This is enabled using the `anymore` cargo feature.
+If this feature is enabled, this crate's MSRV is the same as Anymore's.
+
 ## Unsafe code in this library
 
 This library uses a fair bit of unsafe code for several reasons:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ assert_eq!(&*data.get::<Foo>().unwrap().str, "foot");
 - Add `Send` or `Send + Sync` bounds.
 - You can opt into making the map `Clone`. (In theory you could add all kinds of other functionality, but you can’t readily make this work *generically*, and the bones of it are simple enough that it becomes better to make your own extension of `Any` and reimplement `AnyMap`.)
 - no_std if you like.
+- (Optional) Support for [`anymore`'s `AnyDebug` trait](https://docs.rs/anymore/1.0.0/anymore/trait.AnyDebug.html), for debuggability.
 
 ## Cargo features/dependencies/usage
 

--- a/changelog.d/3z106z90.feature.md
+++ b/changelog.d/3z106z90.feature.md
@@ -1,0 +1,1 @@
+Support the `AnyDebug` trait from the [`anymore` crate](https://github.com/linebender/anymore). Enable with `anymore` crate feature. Contributed by @DJMcNab.

--- a/src/any.rs
+++ b/src/any.rs
@@ -168,3 +168,12 @@ implement!(CloneAny + Send + Sync);
 impl_clone!(dyn CloneAny);
 impl_clone!(dyn CloneAny + Send);
 impl_clone!(dyn CloneAny + Send + Sync);
+
+#[cfg(feature = "anymore")]
+use anymore::AnyDebug;
+#[cfg(feature = "anymore")]
+implement!(AnyDebug);
+#[cfg(feature = "anymore")]
+implement!(AnyDebug + Send);
+#[cfg(feature = "anymore")]
+implement!(AnyDebug + Send + Sync);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -693,9 +693,6 @@ fn type_id_hasher() {
             );
         }
     }
-    // TODO: As of (presumably) https://github.com/rust-lang/rust/pull/121358, these tests fail
-    // Presumably, this is an endianness issue - debug printing shows that the bits which are output
-    // are a subset of the correct bits.
     // Pick a variety of types, just to demonstrate it’s all sane. Normal, zero-sized, unsized, &c.
     verify_hashing_with(TypeId::of::<usize>());
     verify_hashing_with(TypeId::of::<()>());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,6 +652,9 @@ fn type_id_hasher() {
             unsafe { core::mem::transmute::<TypeId, u128>(type_id) } as u64
         );
     }
+    // TODO: As of (presumably) https://github.com/rust-lang/rust/pull/121358, these tests fail
+    // Presumably, this is an endianness issue - debug printing shows that the bits which are output
+    // are a subset of the correct bits.
     // Pick a variety of types, just to demonstrate it’s all sane. Normal, zero-sized, unsized, &c.
     verify_hashing_with(TypeId::of::<usize>());
     verify_hashing_with(TypeId::of::<()>());

--- a/test
+++ b/test
@@ -7,7 +7,7 @@ run_tests() {
 		cargo $1 test $release --no-default-features  # Not very useful without std or hashbrown, but hey, it works! (Doctests emit an error about needing a global allocator, but it exits zero anyway. ¯\_(ツ)_/¯)
 		cargo $1 test $release --no-default-features --features hashbrown
 		cargo $1 test $release
-		cargo $1 test $release --all-features
+		cargo $1 test $release --features std,hashbrown
 	done
 }
 
@@ -19,6 +19,10 @@ cp test-oldest-Cargo.lock Cargo.lock
 run_tests +1.36.0
 rm Cargo.lock
 run_tests
+
+# We only test anymore on stable, as it has a 1.82 MSRV.
+cargo test --features anymore
+cargo test --no-default-features --features anymore,hashbrown
 
 cargo clippy
 cargo bench


### PR DESCRIPTION
See https://docs.rs/anymore/latest/anymore/
Fixes https://github.com/reivilibre/anymap3/issues/4

This library is in a bit of a poor state code-quality wise:
- we no longer work with `no_std` (as of #2)
- the tests fail on stable (see the comment I've added)
- our tests don't compile on our MSRV (despite the `test` script)

I've tested this to the best of my abilities, but there's only so much I can work around.