### PR TITLE
Fix `type_id_hasher` test, Increase Minimum Supported Rust Version to 1.56, Use edition 2021

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
-          - 1.36.0
+          - 1.56.0
           - stable
         features:
           # std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "anymap3"
 version = "1.0.1"
 authors = ["Olivier 'reivilibre' (fork maintainer) <contact@librepush.net>", "Chris Morgan (original author) <rust@chrismorgan.info>"]
-edition = "2018"
-rust-version = "1.36"
+edition = "2021"
+rust-version = "1.56"
 description = "A safe and convenient store for one value of each type"
 repository = "https://github.com/reivilibre/anymap3"
 keywords = ["container", "any", "map"]

--- a/changelog.d/5117772w.removal.md
+++ b/changelog.d/5117772w.removal.md
@@ -1,0 +1,1 @@
+Increase Minimum Supported Rust Version (MSRV) to 1.56 (October 2021).

--- a/changelog.d/w5uvz346.misc.md
+++ b/changelog.d/w5uvz346.misc.md
@@ -1,0 +1,1 @@
+Fix our tests to work with new Rust versions, which changed the internal representation of `TypeId`. Runtime behaviour was unaffected.

--- a/src/any.rs
+++ b/src/any.rs
@@ -59,7 +59,7 @@ macro_rules! impl_clone {
                 // described in [1], that is the recommended way to suppress the warning.
                 //
                 // [1]: https://github.com/rust-lang/rust/issues/127323
-                unsafe { Box::from_raw(std::mem::transmute::<*mut dyn CloneAny, *mut _>(raw)) }
+                unsafe { Box::from_raw(core::mem::transmute::<*mut dyn CloneAny, *mut _>(raw)) }
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -644,32 +644,54 @@ fn type_id_hasher() {
         let mut hasher = TypeIdHasher::default();
         type_id.hash(&mut hasher);
 
-        // Internally, the TypeId is a 128-bit value and depending on
-        // Rust version it will provide either the top or bottom 64 bits
-        // as hash input.
+        // Internally, the TypeId is (depending on Rust version)
+        // either a 64-bit or 128-bit value.
+        // Depending on Rust version it will provide either the top
+        // or bottom 64 bits as hash input.
         // It's not pretty that we're coupled to this, but at runtime
         // the assumption around hash input size is memory-safe
         // (with an additional debug assertion).
         // This evil transmutation is just about OK for a test.
         // It will at least alert us when something changes.
-        let raw_internal_value: u128 = unsafe { core::mem::transmute::<TypeId, u128>(type_id) };
 
-        // Bottom bits expected on earlier Rusts
-        let expected_value_old_rust = raw_internal_value as u64;
-        // Top bits expected nowadays
-        let expected_value_new_rust = (raw_internal_value >> 64) as u64;
+        if core::mem::size_of::<TypeId>() == core::mem::size_of::<u64>() {
+            // Old Rust only
+            let expected_value_old_rust: u64 =
+                *unsafe { core::mem::transmute::<&TypeId, &u64>(&type_id) };
 
-        let got_value = hasher.finish();
+            let got_value = hasher.finish();
 
-        assert!(
-            got_value == expected_value_old_rust || got_value == expected_value_new_rust,
-            "Hash value from TypeId unexpected. Got {:016x},
-            expected either {:016x} (old Rust)
-            or {:016x} (new Rust)",
-            got_value,
-            expected_value_old_rust,
-            expected_value_new_rust,
-        );
+            assert!(
+                got_value == expected_value_old_rust,
+                "Hash value from TypeId unexpected. Got {:016x},
+                expected {:016x} [using TypeId of size u64]",
+                got_value,
+                expected_value_old_rust,
+            );
+        } else {
+            // On newer Rusts, the internal state is currently u128
+            let raw_internal_value: &[u64; 2] =
+                unsafe { core::mem::transmute::<&TypeId, &[u64; 2]>(&type_id) };
+
+            // Even at u128 size, the expected value seems to
+            // depend on version of Rust
+            // (Going by the history of this test code)
+            let expected_value_old_rust = raw_internal_value[0] as u64;
+            let expected_value_new_rust = raw_internal_value[1] as u64;
+
+            let got_value = hasher.finish();
+
+            assert!(
+                got_value == expected_value_old_rust || got_value == expected_value_new_rust,
+                "Hash value from TypeId unexpected. Got {:016x},
+                expected either {:016x} (oldish Rust)
+                or {:016x} (newish Rust) [using TypeId of size {}]",
+                got_value,
+                expected_value_old_rust,
+                expected_value_new_rust,
+                core::mem::size_of::<TypeId>()
+            );
+        }
     }
     // Pick a variety of types, just to demonstrate it’s all sane. Normal, zero-sized, unsized, &c.
     verify_hashing_with(TypeId::of::<usize>());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@
 #![warn(missing_docs, unused_results)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use core::convert::TryInto;
+use core::convert::TryFrom;
 use core::hash::Hasher;
 
 #[cfg(not(feature = "std"))]
@@ -625,9 +625,10 @@ impl Hasher for TypeIdHasher {
         // contract for safety. But I’m OK with release builds putting everything in one bucket
         // if it *did* change (and debug builds panicking).
         debug_assert_eq!(bytes.len(), 8);
-        let _ = bytes
-            .try_into()
-            .map(|array| self.value = u64::from_ne_bytes(array));
+
+        if let Ok(array) = <[u8; 8]>::try_from(bytes) {
+            self.value = u64::from_ne_bytes(array);
+        }
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ macro_rules! everything {
 
             /// Gets the entry for the given type in the collection for in-place manipulation
             #[inline]
-            pub fn entry<T: IntoBox<A>>(&mut self) -> Entry<A, T> {
+            pub fn entry<T: IntoBox<A>>(&mut self) -> Entry<'_, A, T> {
                 match self.raw.entry(TypeId::of::<T>()) {
                     hash_map::Entry::Occupied(e) => Entry::Occupied(OccupiedEntry {
                         inner: e,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,10 +573,7 @@ macro_rules! everything {
             #[test]
             fn test_extend() {
                 let mut map = AnyMap::new();
-                // (vec![] for 1.36.0 compatibility; more recently, you should use [] instead.)
-                #[cfg(not(feature = "std"))]
-                use alloc::vec;
-                map.extend(vec![Box::new(123) as Box<dyn Any>, Box::new(456), Box::new(true)]);
+                map.extend([Box::new(123) as Box<dyn Any>, Box::new(456), Box::new(true)]);
                 assert_eq!(map.get(), Some(&456));
                 assert_eq!(map.get::<bool>(), Some(&true));
                 assert!(map.get::<Box<dyn Any>>().is_none());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -643,11 +643,29 @@ fn type_id_hasher() {
     fn verify_hashing_with(type_id: TypeId) {
         let mut hasher = TypeIdHasher::default();
         type_id.hash(&mut hasher);
-        // SAFETY: u128 and u64 are valid for all bit patterns. Transmute checks the sizes match.
-        // TypeId has a u128 internal value nowadays but only emits the lower 64 bits for its hash.
-        assert_eq!(
-            hasher.finish(),
-            unsafe { core::mem::transmute::<TypeId, u128>(type_id) } as u64
+
+        // Internally, the TypeId is a 128-bit value and depending on
+        // Rust version it will provide either the top or bottom 64 bits
+        // as hash input.
+        // It's not pretty that we're coupled to this, but at runtime
+        // the assumption around hash input size is memory-safe
+        // (with an additional debug assertion).
+        // This evil transmutation is just about OK for a test.
+        // It will at least alert us when something changes.
+        let raw_internal_value: u128 = unsafe { core::mem::transmute::<TypeId, u128>(type_id) };
+
+        // Bottom bits expected on earlier Rusts
+        let expected_value_old_rust = raw_internal_value as u64;
+        // Top bits expected nowadays
+        let expected_value_new_rust = (raw_internal_value >> 64) as u64;
+
+        let got_value = hasher.finish();
+
+        assert!(
+            got_value == expected_value_old_rust || got_value == expected_value_new_rust,
+            "Hash value from TypeId unexpected. Got {got_value:016x},
+            expected either {expected_value_old_rust:016x} (old Rust)
+            or {expected_value_new_rust:016x} (new Rust)",
         );
     }
     // Pick a variety of types, just to demonstrate it’s all sane. Normal, zero-sized, unsized, &c.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,9 +663,12 @@ fn type_id_hasher() {
 
         assert!(
             got_value == expected_value_old_rust || got_value == expected_value_new_rust,
-            "Hash value from TypeId unexpected. Got {got_value:016x},
-            expected either {expected_value_old_rust:016x} (old Rust)
-            or {expected_value_new_rust:016x} (new Rust)",
+            "Hash value from TypeId unexpected. Got {:016x},
+            expected either {:016x} (old Rust)
+            or {:016x} (new Rust)",
+            got_value,
+            expected_value_old_rust,
+            expected_value_new_rust,
         );
     }
     // Pick a variety of types, just to demonstrate it’s all sane. Normal, zero-sized, unsized, &c.


### PR DESCRIPTION
- `type_id_hasher` test was tightly coupled to stdlib memory layout. It still *is*, but now accepts both old and new layout.
- Runtime behaviour was not at risk in either case.
- Edition 2021 supported since 1.56 has more sane support for the inline placeholders in `panic!`. But it turns out 1.56 still doesn't support that properly in `assert!`... Still, 1.56 is nearly 5 years old, I think it's OK to bump a bit.